### PR TITLE
milliseconds should be optional

### DIFF
--- a/src/timeago.coffee
+++ b/src/timeago.coffee
@@ -69,7 +69,7 @@ class TimeAgo
 
   parse: (iso8601) ->
     timeStr = $.trim(iso8601)
-    timeStr = timeStr.replace(/\.\d\d\d+/,"")
+    timeStr = timeStr.replace(/\.\d+/,"")
     timeStr = timeStr.replace(/-/,"/").replace(/-/,"/")
     timeStr = timeStr.replace(/T/," ").replace(/Z/," UTC")
     timeStr = timeStr.replace(/([\+\-]\d\d)\:?(\d\d)/," $1$2")


### PR DESCRIPTION
Nice and useful plugin. However, it outputs NaN on timestamps that doesn't have three millisecond digits. This pull request will fix that.

Thanks
Jonas
