### PR TITLE
Title attribute + minor optimizations

### DIFF
--- a/src/timeago.coffee
+++ b/src/timeago.coffee
@@ -39,6 +39,9 @@ class TimeAgo
     @$element.findAndSelf(@options.selector).each ->
       $el = $(this)
       timeAgoInWords = self.timeAgoInWords($el.attr(self.options.attr))
+      unless $el.prop('title')
+          text = $el.text()
+          $el.prop('title', $el.text()) if text
       $el.html(timeAgoInWords)
 
   updateInterval: ->

--- a/src/timeago.coffee
+++ b/src/timeago.coffee
@@ -19,9 +19,7 @@ class TimeAgo
 
   startTimer: ->
     self = @
-    @interval = setInterval ( ->
-      self.refresh()
-    ), @startInterval
+    @interval = setInterval $.proxy(self.refresh, this), @startInterval
 
   stopTimer: ->
     clearInterval(@interval)

--- a/src/timeago.coffee
+++ b/src/timeago.coffee
@@ -37,8 +37,9 @@ class TimeAgo
   updateTime: ->
     self = @
     @$element.findAndSelf(@options.selector).each ->
-      timeAgoInWords = self.timeAgoInWords($(this).attr(self.options.attr))
-      $(this).html(timeAgoInWords)
+      $el = $(this)
+      timeAgoInWords = self.timeAgoInWords($el.attr(self.options.attr))
+      $el.html(timeAgoInWords)
 
   updateInterval: ->
     if @$element.findAndSelf(@options.selector).length > 0


### PR DESCRIPTION
Set the 'title' attribute of the timeago element to be the text from the element.

(Only happens the first time we wipe the original text, and only if a 'title' wasn't already set).

This allows your original HTML (before JS runs) to have a human readable date like "April 11, 2014" and then have smart-time-ago make it say "1 month ago" but then the user can still hover their mouse to see the more detailed/accurate format of the date.

`<time class="timeago" datetime="2014-04-11">April 11, 2014</time>`

Of course, a tooltip could be done already without this PR if you make the original HTML like this:

`<time class="timeago" datetime="2014-04-11" title="April 11, 2014">April 11, 2014</time>`

However having the 'title' before the text has changed is redundant, and not in the spirit of JS gracefully enhancing the page
